### PR TITLE
migrate to eslint:8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/halkeye/eslint-formatter-multiple#readme",
   "devDependencies": {
-    "eslint": "^7.20.0",
+    "eslint": "^8.0.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
See https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0

I've no idea how to pass the `args` to the `formatter` since it uses something else. 

I tried this PR locally and it generated different output, so please bear with me if there are some missing changes to be applied