### PR TITLE
Await Formatter Results in eslint-formatter-multiple

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
-
-const { existsSync, writeFileSync } = require('fs');
-const { dirname, resolve } = require('path');
-const { sync: mkdirp } = require('mkdirp');
-const { ESLint } = require('eslint');
+const { existsSync, writeFileSync } = require("fs");
+const { dirname, resolve } = require("path");
+const { sync: mkdirp } = require("mkdirp");
+const { ESLint } = require("eslint");
 
 const eslint = new ESLint();
 
-function findConfig () {
+function findConfig() {
   let root = resolve(process.cwd());
-  while (existsSync(root + '/package.json')) {
-    const config = require(root + '/package.json');
-    if (config['eslint-formatter-multiple']) {
-      return config['eslint-formatter-multiple'];
+  while (existsSync(root + "/package.json")) {
+    const config = require(root + "/package.json");
+    if (config["eslint-formatter-multiple"]) {
+      return config["eslint-formatter-multiple"];
     }
-    root = resolve(root + '/../');
+    root = resolve(root + "/../");
   }
   return null;
 }
@@ -23,22 +22,24 @@ module.exports = async function (results, args) {
   const config = findConfig();
 
   if (!config) {
-    console.error('Unable to find a package config that has eslint-formatter-multiple. See README');
+    console.error(
+      "Unable to find a package config that has eslint-formatter-multiple. See README"
+    );
     return false;
   }
 
   for (const formatterConfig of config.formatters || []) {
     const formatter = await eslint.loadFormatter(formatterConfig.name);
-    const formatterResult = formatter.format(results);
-    if (formatterConfig.output === 'console') {
+    const formatterResult = await formatter.format(results);
+    if (formatterConfig.output === "console") {
       console.log(formatterResult);
-    } else if (formatterConfig.output === 'file') {
+    } else if (formatterConfig.output === "file") {
       const filePath = resolve(root, formatterConfig.path);
       try {
         mkdirp(dirname(filePath));
         writeFileSync(filePath, formatterResult);
       } catch (ex) {
-        console.error('There was a problem writing the output file:\n%s', ex);
+        console.error("There was a problem writing the output file:\n%s", ex);
 
         return false;
       }


### PR DESCRIPTION
This PR updates the `eslint-formatter-multiple` package to handle asynchronous formatters correctly. Previously, some ESLint formatters that return results asynchronously (e.g., [eslint-formatter-gha](https://www.npmjs.com/package/eslint-formatter-gha)) were not being processed correctly, resulting in unexpected output like:

```
Promise {
'::group::ESLint Annotations\n' +
'::error file=/path/to/file.tsx,line=55,col=30::Missing return type on function.\n' +
'::error file=/path/to/file.tsx,line=55,col=30::Missing return type on function.\n' +
'::endgroup::\n'
}
```
This PR resolves the issue by awaiting the formatter results before processing them.

### Additional Notes
This change ensures compatibility with asynchronous formatters while maintaining support for synchronous ones. It's a minor but important update to improve the reliability of the `eslint-formatter-multiple` package.
